### PR TITLE
Preventing from CompletionController triggering in interactive/FSI

### DIFF
--- a/EmojiVS.csproj
+++ b/EmojiVS.csproj
@@ -30,6 +30,9 @@
     <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Intellisense/CompletionController.cs
+++ b/Intellisense/CompletionController.cs
@@ -28,7 +28,7 @@ namespace Emoji.Intellisense
 {
 	[Export(typeof(IVsTextViewCreationListener))]
 	[ContentType("text")]
-	[TextViewRole(PredefinedTextViewRoles.Interactive)]
+	[TextViewRole(PredefinedTextViewRoles.Document)]
 	internal sealed class VsTextViewCreationListener : IVsTextViewCreationListener
 	{
 		[Import]


### PR DESCRIPTION
When triggering completion (Ctrl-Space) in the F# Interactive window, this would cause an error with out of range index.
Changing to `Document` role to prevent it.

This shows again that [FSI should have its own content type](https://github.com/Microsoft/visualfsharp/issues/512).
